### PR TITLE
Fix name of `github_token` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If vulnerabilities are found by `npm audit`, Action triggered by push, schedule 
 |issue_assignees|false|N/A|Issue assignees (separated by commma)|
 |issue_labels|false|N/A|Issue labels (separated by commma)|
 |issue_title|false|npm audit found vulnerabilities|Issue title|
-|token|true|N/A|GitHub Access Token.<br>${{ secrets.GITHUB_TOKEN }} is recommended.|
+|github_token|true|N/A|GitHub Access Token.<br>${{ secrets.GITHUB_TOKEN }} is recommended.|
 |working_directory|false|N/A|The directory which contains package.json (since v1.4.0)|
 |dedupe_issues|false|false|If 'true', action will not create a new issue when one is already open (since v1.5.0)|
 


### PR DESCRIPTION
It was correctly `github_token` in the code and examples, but it was shown as `token` in the docs.