### PR TITLE
Retain spaces within label

### DIFF
--- a/__tests__/issue.test.ts
+++ b/__tests__/issue.test.ts
@@ -41,6 +41,20 @@ describe('getIssueOption', () => {
     }
     expect(issue.getIssueOption('hi')).toEqual(expected)
   })
+
+  test('with label containing spaces', () => {
+    process.env.INPUT_ISSUE_TITLE = 'npm audit found vulnerabilities'
+    process.env.INPUT_ISSUE_ASSIGNEES = 'alice'
+    process.env.INPUT_ISSUE_LABELS = 'status: ready, work: frontend'
+
+    const expected: IssueOption = {
+      title: 'npm audit found vulnerabilities',
+      body: 'hi',
+      assignees: ['alice'],
+      labels: ['status: ready', 'work: frontend']
+    }
+    expect(issue.getIssueOption('hi')).toEqual(expected)
+  })
 })
 
 describe('getExistingIssueNumber', () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -104,7 +104,7 @@ function getIssueOption(body) {
         assignees = core.getInput('issue_assignees').replace(/\s+/g, '').split(',');
     }
     if (core.getInput('issue_labels')) {
-        labels = core.getInput('issue_labels').replace(/\s+/g, '').split(',');
+        labels = core.getInput('issue_labels').split(',').map(label => label.trim());
     }
     return {
         title: core.getInput('issue_title'),

--- a/src/issue.ts
+++ b/src/issue.ts
@@ -9,7 +9,7 @@ export function getIssueOption(body: string): IssueOption {
     assignees = core.getInput('issue_assignees').replace(/\s+/g, '').split(',')
   }
   if (core.getInput('issue_labels')) {
-    labels = core.getInput('issue_labels').replace(/\s+/g, '').split(',')
+    labels = core.getInput('issue_labels').split(',').map(label => label.trim())
   }
 
   return {


### PR DESCRIPTION
Fixes https://github.com/oke-py/npm-audit-action/issues/94

**Details:**
This PR retains spaces within the labels in the raised issue.

Consider `issue_labels` has the value: `status: ready, work: frontend`.

Previous labels assigned:  `status:ready`, `work:frontend`.
This PR fixes it to be: `status: ready`, `work: frontend`.