### PR TITLE
Fix Commit - Committing fix whereby NPM Audit Actions Fails when running on Window OS

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   scan:
     name: npm audit
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,10 @@ on: # rebuild any PRs and main branch changes
 
 jobs:
   build: # make sure build/ci work properly
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - run: |
@@ -17,8 +20,12 @@ jobs:
     - uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+
   test: # make sure the action works on a clean machine without building
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Dump GitHub context
       env:

--- a/dist/index.js
+++ b/dist/index.js
@@ -21,6 +21,9 @@ class Audit {
     }
     run(auditLevel, productionFlag, jsonFlag) {
         try {
+            const isWindowsEnvironment = process.platform == "win32";
+            const cmd = (isWindowsEnvironment) ? 'npm.cmd' : 'npm';
+
             const auditOptions = ['audit', '--audit-level', auditLevel];
             if (productionFlag === 'true') {
                 auditOptions.push('--production');
@@ -28,7 +31,8 @@ class Audit {
             if (jsonFlag === 'true') {
                 auditOptions.push('--json');
             }
-            const result = child_process_1.spawnSync('npm', auditOptions, {
+
+            const result = child_process_1.spawnSync(cmd, auditOptions, {
                 encoding: 'utf-8',
                 maxBuffer: SPAWN_PROCESS_BUFFER_SIZE
             });

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -15,6 +15,9 @@ export class Audit {
     try {
       const auditOptions: Array<string> = ['audit', '--audit-level', auditLevel]
 
+      const isWindowsEnvironment: boolean = process.platform == "win32";
+      const cmd: string = (isWindowsEnvironment) ? 'npm.cmd' : 'npm';
+
       if (productionFlag === 'true') {
         auditOptions.push('--production')
       }
@@ -23,7 +26,7 @@ export class Audit {
         auditOptions.push('--json')
       }
 
-      const result: SpawnSyncReturns<string> = spawnSync('npm', auditOptions, {
+      const result: SpawnSyncReturns<string> = spawnSync(cmd, auditOptions, {
         encoding: 'utf-8',
         maxBuffer: SPAWN_PROCESS_BUFFER_SIZE
       })


### PR DESCRIPTION
- _This commit is to fix an issue when running the 'npm-audit-action' on the 'windows-latest'_
- _Integrated the 'spawnSync' to use the right 'npm' script based upon the OS used_

_Note - Associated [Issue](https://github.com/oke-py/npm-audit-action/issues/123) with specified Issue identified when running the 'npm-audit-action' on a Window OS_ 