### PR TITLE
Update action.yml - ubuntu move from 16 to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ outputs:
   npm_audit:
     description: 'The output of the npm audit report in a text format'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'search'


### PR DESCRIPTION
Remove job warns
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/