### PR TITLE
Disable test-on-windows job temporarily

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,32 +72,32 @@ jobs:
         create_issues: false
         production_flag: true
 
-  test-on-windows:
-    strategy:
-      matrix:
-        node: [20]
-    runs-on: windows-latest
-    steps:
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node }}
-    # Node.js 20 already includes a recent npm version, so npm upgrade is not needed
-    - name: Run npm audit action
-      uses: ./
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        issue_title: npm audit run by test job
-        create_issues: false
-        production_flag: true
-    - name: Run npm audit action in testdata workdir
-      uses: ./
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        working_directory: __tests__/testdata/workdir/
-        create_issues: false
-        production_flag: true
+  # test-on-windows:
+  #   strategy:
+  #     matrix:
+  #       node: [20]
+  #   runs-on: windows-latest
+  #   steps:
+  #   - name: Dump GitHub context
+  #     env:
+  #       GITHUB_CONTEXT: ${{ toJson(github) }}
+  #     run: echo "$GITHUB_CONTEXT"
+  #   - uses: actions/checkout@v4
+  #   - uses: actions/setup-node@v4
+  #     with:
+  #       node-version: ${{ matrix.node }}
+  #   # Node.js 20 already includes a recent npm version, so npm upgrade is not needed
+  #   - name: Run npm audit action
+  #     uses: ./
+  #     with:
+  #       github_token: ${{ secrets.GITHUB_TOKEN }}
+  #       issue_title: npm audit run by test job
+  #       create_issues: false
+  #       production_flag: true
+  #   - name: Run npm audit action in testdata workdir
+  #     uses: ./
+  #     with:
+  #       github_token: ${{ secrets.GITHUB_TOKEN }}
+  #       working_directory: __tests__/testdata/workdir/
+  #       create_issues: false
+  #       production_flag: true


### PR DESCRIPTION
This PR temporarily disables the test-on-windows job in GitHub Actions workflow to address issues with the Windows test environment.

Changes:

- Comment out the entire test-on-windows job in .github/workflows/test.yml
- Keep all other jobs (build, build-on-windows, test) enabled

This change will help stabilize the CI pipeline while we investigate and fix the underlying issues with the Windows test environment.