### PR TITLE
Update @actions/core from 1.10.1 to 1.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.4.4",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.10.1",
+        "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.0",
         "@octokit/rest": "^21.1.1",
         "strip-ansi": "^6.0.1"
@@ -44,12 +44,22 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "license": "MIT",
       "dependencies": {
-        "@actions/http-client": "^2.0.1",
-        "uuid": "^8.3.2"
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
       }
     },
     "node_modules/@actions/github": {
@@ -73,6 +83,12 @@
         "tunnel": "^0.0.6",
         "undici": "^5.25.4"
       }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -7084,14 +7100,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.3",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
@@ -7279,12 +7287,20 @@
       "dev": true
     },
     "@actions/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
       "requires": {
-        "@actions/http-client": "^2.0.1",
-        "uuid": "^8.3.2"
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
+      }
+    },
+    "@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "requires": {
+        "@actions/io": "^1.0.1"
       }
     },
     "@actions/github": {
@@ -7306,6 +7322,11 @@
         "tunnel": "^0.0.6",
         "undici": "^5.25.4"
       }
+    },
+    "@actions/io": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
     },
     "@ampproject/remapping": {
       "version": "2.2.0",
@@ -12370,11 +12391,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-to-istanbul": {
       "version": "9.1.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Naoki Oketani <okepy.naoki@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.10.1",
+    "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.0",
     "@octokit/rest": "^21.1.1",
     "strip-ansi": "^6.0.1"


### PR DESCRIPTION
This PR updates the @actions/core package from version 1.10.1 to 1.11.1.

All tests are passing successfully with the updated package.