### PR TITLE
fix(tsconfig): exclude vitest.config.ts from TypeScript compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "noImplicitAny": true,                    /* Raise error on expressions and declarations with an implied 'any' type. */
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
   },
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "exclude": ["node_modules", "**/*.test.ts", "vitest.config.ts"]
 }


### PR DESCRIPTION
### What changes were made
Updated `tsconfig.json` to exclude `vitest.config.ts` from TypeScript compilation.

### Why these changes were necessary
To prevent build failures caused by files outside the `rootDir`.

### Potential side effects
None expected.

### Areas to test
- Ensure TypeScript builds successfully.
- Verify that `vitest.config.ts` is excluded from compilation.

### Related Issue
Closes #224 