### PR TITLE
fix: limit test coverage to src directory only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies and run tests
       run: |
         npm ci
-        npm run test -- --run --coverage
+        npm run test:coverage
     - uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -38,7 +38,7 @@ jobs:
     - name: Install dependencies and run tests
       run: |
         npm ci
-        npm run test -- --run
+        npm run test
 
   test: # make sure the action works on a clean machine without building
     strategy:

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "format-check": "prettier --check **/*.ts",
     "lint": "eslint src/**/*.ts",
     "pack": "ncc build --v8-cache --source-map --target es2020",
-    "test": "vitest",
-    "test:coverage": "vitest --coverage",
+    "test": "vitest --run",
+    "test:coverage": "vitest --run --coverage",
     "all": "npm run build && npm run format && npm run lint && npm run pack && npm run test:coverage"
   },
   "repository": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
@@ -6,7 +6,9 @@ export default defineConfig({
     environment: 'node',
     include: ['__tests__/**/*.test.ts'],
     coverage: {
-      reporter: ['text', 'json', 'html', 'lcov'],
-    },
-  },
-});
+      include: ['src/**/*.ts'], // Only target the src directory
+      exclude: ['lib/**'], // Exclude the lib directory
+      reporter: ['text', 'json', 'html', 'lcov']
+    }
+  }
+})


### PR DESCRIPTION
Limited test coverage to the `src` directory only, excluding the `lib` directory.

## Changes

1. Added `include: ["src/**/*.ts"]` and `exclude: ["lib/**"]` to the coverage configuration in `vitest.config.ts`
2. Added the `--run` option to the test scripts in `package.json`
3. Updated GitHub Actions workflow to use the new test scripts