### PR TITLE
fix: resolve prettier and eslint conflict by removing bracketSpacing: false

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,11 +1,10 @@
 {
-    "printWidth": 80,
-    "tabWidth": 2,
-    "useTabs": false,
-    "semi": false,
-    "singleQuote": true,
-    "trailingComma": "none",
-    "bracketSpacing": false,
-    "arrowParens": "avoid",
-    "parser": "typescript"
-  }
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "arrowParens": "avoid",
+  "parser": "typescript"
+}

--- a/__tests__/audit.test.ts
+++ b/__tests__/audit.test.ts
@@ -1,9 +1,9 @@
 import * as child_process from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
-import {Audit} from '../src/audit'
-import {fileURLToPath} from 'url'
-import {dirname} from 'path'
+import { Audit } from '../src/audit'
+import { fileURLToPath } from 'url'
+import { dirname } from 'path'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)

--- a/__tests__/issue.test.ts
+++ b/__tests__/issue.test.ts
@@ -1,5 +1,5 @@
 import * as issue from '../src/issue'
-import {IssueOption} from '../src/interface'
+import { IssueOption } from '../src/interface'
 
 describe('getIssueOption', () => {
   test('without assignee and label', () => {
@@ -77,7 +77,10 @@ describe('getExistingIssueNumber', () => {
         }
       ]
     })
-    const result = await issue.getExistingIssueNumber(getIssues, {repo, owner})
+    const result = await issue.getExistingIssueNumber(getIssues, {
+      repo,
+      owner
+    })
 
     expect(getIssues).toHaveBeenCalledWith({
       repo,
@@ -90,9 +93,12 @@ describe('getExistingIssueNumber', () => {
 
   test('returns null when there is no open issue', async () => {
     const getIssues = vi.fn()
-    getIssues.mockResolvedValue({data: []})
+    getIssues.mockResolvedValue({ data: [] })
 
-    const result = await issue.getExistingIssueNumber(getIssues, {repo, owner})
+    const result = await issue.getExistingIssueNumber(getIssues, {
+      repo,
+      owner
+    })
 
     expect(getIssues).toHaveBeenCalledWith({
       repo,
@@ -114,7 +120,10 @@ describe('getExistingIssueNumber', () => {
       ]
     })
 
-    const result = await issue.getExistingIssueNumber(getIssues, {repo, owner})
+    const result = await issue.getExistingIssueNumber(getIssues, {
+      repo,
+      owner
+    })
 
     expect(getIssues).toHaveBeenCalledWith({
       repo,

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,11 +1,11 @@
 import * as fs from 'fs'
 import * as path from 'path'
-import {Audit} from '../src/audit'
-import {run} from '../src/main'
+import { Audit } from '../src/audit'
+import { run } from '../src/main'
 import * as issue from '../src/issue'
 import * as pr from '../src/pr'
-import {fileURLToPath} from 'url'
-import {dirname} from 'path'
+import { fileURLToPath } from 'url'
+import { dirname } from 'path'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -1,4 +1,4 @@
-import {spawnSync, SpawnSyncReturns} from 'child_process'
+import { spawnSync, SpawnSyncReturns } from 'child_process'
 import stripAnsi from 'strip-ansi'
 
 const SPAWN_PROCESS_BUFFER_SIZE = 10485760 // 10MiB

--- a/src/issue.ts
+++ b/src/issue.ts
@@ -1,5 +1,5 @@
 import * as core from '@actions/core'
-import {IssueOption} from './interface.js'
+import { IssueOption } from './interface.js'
 
 export function getIssueOption(body: string): IssueOption {
   let assignees: string[] | undefined
@@ -29,7 +29,7 @@ export type GetIssuesFunc = (options: {
   state: 'open' | 'closed' | 'all' | undefined
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any // Allow additional properties
-}) => Promise<{data: Array<{title: string; number: number}>}>
+}) => Promise<{ data: Array<{ title: string; number: number }> }>
 
 export async function getExistingIssueNumber(
   getIssues: GetIssuesFunc,
@@ -38,7 +38,7 @@ export async function getExistingIssueNumber(
     repo: string
   }
 ): Promise<number | null> {
-  const {data: issues} = await getIssues({
+  const { data: issues } = await getIssues({
     ...repo,
     state: 'open'
   })

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
-import {Octokit} from '@octokit/rest'
-import {Audit} from './audit.js'
-import {IssueOption} from './interface.js'
+import { Octokit } from '@octokit/rest'
+import { Audit } from './audit.js'
+import { IssueOption } from './interface.js'
 import * as issue from './issue.js'
 import * as pr from './pr.js'
 import * as workdir from './workdir.js'
@@ -20,7 +20,7 @@ export async function run(): Promise<void> {
     core.info(`Current working directory: ${process.cwd()}`)
 
     // get audit-level
-    const auditLevel = core.getInput('audit_level', {required: true})
+    const auditLevel = core.getInput('audit_level', { required: true })
     if (
       !['critical', 'high', 'moderate', 'low', 'info', 'none'].includes(
         auditLevel
@@ -29,12 +29,12 @@ export async function run(): Promise<void> {
       throw new Error('Invalid input: audit_level')
     }
 
-    const productionFlag = core.getInput('production_flag', {required: false})
+    const productionFlag = core.getInput('production_flag', { required: false })
     if (!['true', 'false'].includes(productionFlag)) {
       throw new Error('Invalid input: production_flag')
     }
 
-    const jsonFlag = core.getInput('json_flag', {required: false})
+    const jsonFlag = core.getInput('json_flag', { required: false })
     if (!['true', 'false'].includes(jsonFlag)) {
       throw new Error('Invalid input: json_flag')
     }
@@ -50,7 +50,7 @@ export async function run(): Promise<void> {
 
       // get GitHub information
       const ctx = JSON.parse(core.getInput('github_context'))
-      const token: string = core.getInput('github_token', {required: true})
+      const token: string = core.getInput('github_token', { required: true })
       const octokit = new Octokit({
         auth: token
       })
@@ -97,14 +97,14 @@ export async function run(): Promise<void> {
             : null
 
         if (existingIssueNumber !== null) {
-          const {data: createdComment} = await octokit.issues.createComment({
+          const { data: createdComment } = await octokit.issues.createComment({
             ...github.context.repo,
             issue_number: existingIssueNumber,
             body: option.body
           })
           core.debug(`comment ${createdComment.url}`)
         } else {
-          const {data: createdIssue} = await octokit.issues.create({
+          const { data: createdIssue } = await octokit.issues.create({
             ...github.context.repo,
             ...option
           })

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -1,4 +1,4 @@
-import {Octokit} from '@octokit/rest'
+import { Octokit } from '@octokit/rest'
 
 export async function createComment(
   octokit: Octokit,


### PR DESCRIPTION
Resolved the conflict between Prettier and ESLint configurations by removing the `bracketSpacing: false` setting from `.prettierrc.json`.

## Changes

1. Removed `bracketSpacing: false` from `.prettierrc.json` to use the default value of `true`
2. Ran `npm run format` to update all files with the new formatting rules
3. Verified that ESLint no longer reports errors related to bracket spacing

This change ensures that Prettier and ESLint configurations are consistent, preventing formatting conflicts.