### PR TITLE
docs: add detailed instructions for gh pr create usage

### DIFF
--- a/.clinerules/rules.md
+++ b/.clinerules/rules.md
@@ -84,6 +84,20 @@ This document outlines the development guidelines and best practices for our Typ
   ```bash
   gh pr create --title 'Your PR title' --body 'Detailed description' --base main
   ```
+  - Enclose title and body in single quotes (`'`) to handle spaces and special characters
+  - For multi-line body text, use actual line breaks instead of `\n` escape sequences
+  - Format the body text with Markdown for better readability:
+    ```bash
+    gh pr create --title 'fix: resolve issue with authentication' --body 'Fixed the authentication issue by updating the token validation logic.
+
+    ## Changes
+
+    1. Updated the token validation in `auth.ts`
+    2. Added unit tests for the new validation logic
+    3. Updated documentation
+
+    Fixes #123'
+    ```
 
 ## Code Review
 


### PR DESCRIPTION
This pull request adds detailed instructions for creating pull requests using GitHub CLI.

## Changes

1. Added detailed explanations for using the `gh pr create` command
2. Included guidance on enclosing title and body in single quotes to handle spaces and special characters
3. Added best practices for handling multi-line text in PR descriptions
4. Provided examples of formatting the body text with Markdown for better readability

## Reason for Changes

To clarify project guidelines and ensure team members can create pull requests in a consistent manner.

## Impact

These changes standardize the pull request creation process and encourage more readable and informative pull requests.