### PR TITLE
docs: update clinerules formatting and TypeScript configuration

### DIFF
--- a/.clinerules/rules.md
+++ b/.clinerules/rules.md
@@ -13,15 +13,17 @@ This document outlines the development guidelines and best practices for our Typ
   - Use `module: NodeNext` for the latest Node.js module resolution
   - Use `noImplicitAny: true` to ensure all types are explicitly defined
   - Configure `outDir: "./lib"` and `rootDir: "./src"` to control the output directory structure
+  - Set `baseUrl: "./"` and configure `paths` for module resolution
 
 - **Code Formatting**
   - Use Prettier for consistent code formatting with the following settings:
+    - Maximum line width of 80 characters (`printWidth: 80`)
     - 2-space indentation (`tabWidth: 2`)
     - No semicolons (`semi: false`)
     - Single quotes (`singleQuote: true`)
     - No trailing commas (`trailingComma: "none"`)
-    - No spaces inside brackets (`bracketSpacing: false`)
     - Avoid parentheses around single arrow function parameters (`arrowParens: "avoid"`)
+    - Use TypeScript parser (`parser: "typescript"`)
   - Configure ESLint with TypeScript parser for static code analysis
   - Enforce consistent naming conventions:
     - camelCase for variables and functions


### PR DESCRIPTION
This pull request updates the .clinerules/rules.md file to align with the actual project configuration.

## Changes

1. Updated TypeScript Configuration section:
   - Added `baseUrl: "./"` and `paths` configuration which were present in tsconfig.json but missing in the documentation

2. Updated Code Formatting section:
   - Removed `bracketSpacing: false` as it is not present in the actual .prettierrc.json
   - Added `printWidth: 80` which is present in .prettierrc.json
   - Added `parser: "typescript"` which is present in .prettierrc.json

These changes ensure that the documentation accurately reflects the actual project configuration, making it easier for developers to understand and follow the project standards.