### PR TITLE
feat: update references from v2 to v3 for release v3.0.0

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: install dependencies
         run: npm ci
-      - uses: oke-py/npm-audit-action@v2
+      - uses: oke-py/npm-audit-action@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           issue_assignees: oke-py
@@ -34,7 +34,7 @@ jobs:
           npm-windows-upgrade --npm-version latest
       - name: install dependencies
         run: npm ci
-      - uses: oke-py/npm-audit-action@v2
+      - uses: oke-py/npm-audit-action@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           issue_assignees: oke-py

--- a/.github/workflows/git-tag.yml
+++ b/.github/workflows/git-tag.yml
@@ -1,11 +1,11 @@
-name: "git tag v2"
+name: "git tag major version"
 on:
   release:
     types:
       - published
 
 jobs:
-  v2:
+  tag-major-version:
     runs-on: ubuntu-latest
     steps:
     - name: check out repository code
@@ -17,8 +17,15 @@ jobs:
     - name: git tag
       run: |
         git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
-        git push origin -d v2
-        git tag v2 ${GITHUB_SHA}
-        git push origin v2
+        # Extract major version from release tag (e.g., v3.0.0 -> v3)
+        MAJOR_VERSION=$(echo ${{ github.event.release.tag_name }} | grep -o "^v[0-9]*")
+        echo "Tagging with major version: ${MAJOR_VERSION}"
+
+        # Delete the major version tag if it exists
+        git push origin -d ${MAJOR_VERSION} || true
+
+        # Create and push the new major version tag
+        git tag ${MAJOR_VERSION} ${GITHUB_SHA}
+        git push origin ${MAJOR_VERSION}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ jobs:
     name: npm audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install dependencies
         run: npm ci
-      - uses: oke-py/npm-audit-action@v2
+      - uses: oke-py/npm-audit-action@v3
         with:
           audit_level: moderate
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-audit-action",
-  "version": "2.4.4",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-audit-action",
-      "version": "2.4.4",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-audit-action",
-  "version": "2.4.4",
+  "version": "3.0.0",
   "private": true,
   "description": "GitHub Action to run `npm audit`",
   "main": "lib/main.js",


### PR DESCRIPTION
This PR prepares for the release of npm-audit-action@v3.0.0 with the following changes:

1. README.md: 
   - Updated `oke-py/npm-audit-action@v2` to `oke-py/npm-audit-action@v3`

2. package.json:
   - Updated version from `2.4.4` to `3.0.0`

3. package-lock.json:
   - Automatically updated via `npm install`

4. .github/workflows/daily.yml:
   - Updated two occurrences of `oke-py/npm-audit-action@v2` to `oke-py/npm-audit-action@v3`

5. .github/workflows/git-tag.yml:
   - Changed workflow name from "git tag v2" to "git tag major version"
   - Changed job name from "v2" to "tag-major-version"
   - Modified tagging logic to extract the major version (e.g., v3.0.0 → v3) from the release tag
   - This ensures that when a GitHub Release is created, the latest commit is tagged with the appropriate major version (v3)