### PR TITLE
docs: clarify PR language requirements

### DIFF
--- a/.clinerules/rules.md
+++ b/.clinerules/rules.md
@@ -75,7 +75,7 @@ This document outlines the development guidelines and best practices for our Typ
 
 ### Pull Requests
 
-- Write PR titles and descriptions in English
+- **IMPORTANT**: Write PR titles and descriptions in English ONLY, NOT in Japanese
 - Use clear, descriptive titles that summarize the changes
 - Include detailed descriptions explaining:
   - What changes were made


### PR DESCRIPTION
This PR clarifies the language requirements for pull request titles and descriptions.

## Changes

1. Updated the Pull Requests section in .clinerules/rules.md to explicitly state that PR titles and descriptions must be in English only, not in Japanese.
2. Added emphasis with bold formatting and explicit wording to make the requirement clearer.

This change aims to reduce confusion and ensure all team members follow the English-only policy for PR documentation.