### PR TITLE
fix: set PowerShell execution policy for Windows workflows

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -28,10 +28,16 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+      # Set PowerShell execution policy for this process
+      - name: Set PowerShell execution policy
+        shell: powershell
+        run: Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process -Force
       # https://stackoverflow.com/questions/72401421/message-npm-warn-config-global-global-local-are-deprecated-use-loc
-      - run: |
+      - name: Upgrade npm
+        shell: powershell
+        run: |
           npm install npm-windows-upgrade --location=global
-          npm-windows-upgrade --npm-version latest
+          npm-windows-upgrade --npm-version latest --no-prompt
       - name: install dependencies
         run: npm ci
       - uses: oke-py/npm-audit-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,32 +70,36 @@ jobs:
         create_issues: false
         production_flag: true
 
-  # test-on-windows:
-  #   strategy:
-  #     matrix:
-  #       node: [20]
-  #   runs-on: windows-latest
-  #   steps:
-  #   - name: Dump GitHub context
-  #     env:
-  #       GITHUB_CONTEXT: ${{ toJson(github) }}
-  #     run: echo "$GITHUB_CONTEXT"
-  #   - uses: actions/checkout@v4
-  #   - uses: actions/setup-node@v4
-  #     with:
-  #       node-version: ${{ matrix.node }}
-  #   # Node.js 20 already includes a recent npm version, so npm upgrade is not needed
-  #   - name: Run npm audit action
-  #     uses: ./
-  #     with:
-  #       github_token: ${{ secrets.GITHUB_TOKEN }}
-  #       issue_title: npm audit run by test job
-  #       create_issues: false
-  #       production_flag: true
-  #   - name: Run npm audit action in testdata workdir
-  #     uses: ./
-  #     with:
-  #       github_token: ${{ secrets.GITHUB_TOKEN }}
-  #       working_directory: __tests__/testdata/workdir/
-  #       create_issues: false
-  #       production_flag: true
+  test-on-windows:
+    strategy:
+      matrix:
+        node: [20]
+    runs-on: windows-latest
+    steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node }}
+    # Set PowerShell execution policy for this process
+    - name: Set PowerShell execution policy
+      shell: powershell
+      run: Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process -Force
+    # Node.js 20 already includes a recent npm version, so npm upgrade is not needed
+    - name: Run npm audit action
+      uses: ./
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        issue_title: npm audit run by test job
+        create_issues: false
+        production_flag: true
+    - name: Run npm audit action in testdata workdir
+      uses: ./
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        working_directory: __tests__/testdata/workdir/
+        create_issues: false
+        production_flag: true


### PR DESCRIPTION
## Overview
This PR resolves the PowerShell execution policy issues that occur when running GitHub Actions workflows in Windows environments.
#212 

## Changes
- `test.yml`: Uncommented the test-on-windows job and added a step to set the PowerShell execution policy
- `daily.yml`: Added a step to set the PowerShell execution policy and added the --no-prompt flag to npm-windows-upgrade

## Fix Details
- Used `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process -Force` command to set the execution policy for the current process only
- Explicitly specified `shell: powershell` for the steps
- Added the `--no-prompt` flag to avoid interactive prompts