### PR TITLE
refactor(ci): rename npm script from pack to package and update workflow

### DIFF
--- a/.clinerules/rules.md
+++ b/.clinerules/rules.md
@@ -52,10 +52,9 @@ This document outlines the development guidelines and best practices for our Typ
 
 - **Build Process**
   - Use TypeScript compiler (`tsc`) for building the project
-  - Use `@vercel/ncc` for bundling the code into a single file
-  - Run `npm run build` to compile TypeScript files
-  - Run `npm run pack` to bundle the code with ncc
-  - Run `npm run all` to build, format, lint, pack, and test the project
+  - Use Rollup for bundling the code
+  - Run `npm run package` to bundle the code with Rollup
+  - Run `npm run all` to format, lint, test, and package the project
   - Note that dist/index.js updates are handled by GitHub Actions and should not be included in commits or pull requests
 
 ## Git Workflow

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 jobs:
-  pack:
+  package:
     runs-on: ubuntu-latest
     steps:
     - name: check out repository code
@@ -16,12 +16,9 @@ jobs:
     - name: format TypeScript code
       run: |
         npm run format
-    - name: compile TypeScript code
-      run: |
-        npm run build
     - name: compile TypeScript code into dist/index.js
       run: |
-        npm run pack
+        npm run package
     - uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: "chore(build): automated change"

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "format": "prettier --write **/*.ts",
     "format-check": "prettier --check **/*.ts",
     "lint": "eslint src/**/*.ts",
-    "pack": "npx rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
+    "package": "npx rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
     "test": "vitest --run",
     "test:coverage": "vitest --run --coverage",
-    "all": "npm run format && npm run lint && npm run test:coverage && npm run pack"
+    "all": "npm run format && npm run lint && npm run test:coverage && npm run package"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR renames the npm script from "pack" to "package" and updates the CI workflow accordingly.

## Changes

1. Renamed npm script from "pack" to "package" in package.json
2. Updated the "all" script to use "package" instead of "pack"
3. Updated the CI workflow job name from "pack" to "package"
4. Removed the redundant "npm run build" step from the CI workflow
5. Updated .clinerules/rules.md to reflect these changes

These changes improve consistency in the build process terminology and simplify the CI workflow by removing redundant steps.

Fixes #241