### PR TITLE
refactor(scripts): rename format scripts to format:write and format:check

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
     "node": ">=20.0.0"
   },
   "scripts": {
-    "bundle": "npm run format && npm run package",
-    "format": "prettier --write **/*.ts",
-    "format-check": "prettier --check **/*.ts",
+    "bundle": "npm run format:write && npm run package",
+    "format:write": "npx prettier --write .",
+    "format:check": "npx prettier --check .",
     "lint": "eslint src/**/*.ts",
     "package": "npx rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
     "test": "vitest --run",
     "test:coverage": "vitest --run --coverage",
-    "all": "npm run format && npm run lint && npm run test:coverage && npm run package"
+    "all": "npm run format:write && npm run lint && npm run test:coverage && npm run package"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR renames the npm scripts for code formatting to align with the template repository (actions/typescript-action).

## Changes

1. Renamed `format` to `format:write` and updated the command to `npx prettier --write .`
2. Renamed `format-check` to `format:check` and updated the command to `npx prettier --check .`
3. Updated related scripts (`bundle` and `all`) to use the new script names

## Why

This change aligns our script naming convention with the template repository, making it more consistent and easier to understand.

## Testing

- Run `npm run format:write` to verify it formats the code correctly
- Run `npm run format:check` to verify it checks the code formatting correctly
- Run `npm run bundle` and `npm run all` to verify they work with the new script names