### PR TITLE
refactor(main): remove run() call as index.ts is now the entry point

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -138,5 +138,3 @@ export async function run(): Promise<void> {
     core.setFailed((e as Error)?.message ?? 'Unknown error occurred')
   }
 }
-
-run()


### PR DESCRIPTION
This PR removes the run() call at the end of src/main.ts since src/index.ts has been introduced as the new entry point.

## Changes

1. Removed the run() call at the end of src/main.ts

This change is necessary because the run() function is now being called from src/index.ts, which serves as the new entry point for the action. Having the run() call in both files would result in the function being executed twice.