### PR TITLE
fix: suppress unnecessary output during test execution

### DIFF
--- a/__fixtures__/core.ts
+++ b/__fixtures__/core.ts
@@ -1,0 +1,15 @@
+import type * as core from '@actions/core'
+import { vi } from 'vitest'
+
+export const debug = vi.fn<typeof core.debug>()
+export const error = vi.fn<typeof core.error>()
+export const info = vi.fn<typeof core.info>()
+export const getInput = vi
+  .fn<typeof core.getInput>()
+  .mockImplementation((name, options) => {
+    const key = `INPUT_${name.replace(/ /g, '_').toUpperCase()}`
+    return process.env[key] || ''
+  })
+export const setOutput = vi.fn<typeof core.setOutput>()
+export const setFailed = vi.fn<typeof core.setFailed>()
+export const warning = vi.fn<typeof core.warning>()

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs'
 import * as path from 'path'
+import * as core from '../__fixtures__/core'
 import { Audit } from '../src/audit'
 import { run } from '../src/main'
 import * as issue from '../src/issue'
@@ -10,6 +11,8 @@ import { dirname } from 'path'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
+// Mocks should be declared before the module being tested is imported.
+vi.mock('@actions/core', () => core)
 vi.mock('../src/audit')
 vi.mock('../src/issue')
 vi.mock('../src/pr')

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -7,6 +7,7 @@
   },
   "exclude": ["dist", "node_modules"],
   "include": [
+    "__fixtures__",
     "__tests__",
     "src",
     "eslint.config.mjs",


### PR DESCRIPTION
This PR suppresses unnecessary output during test execution.

Main changes:

1. Created `__fixtures__/core.ts` file to mock the `@actions/core` module
2. Updated test files to use the mock instead of the actual `@actions/core` module

These changes ensure that only test results are displayed during test execution, making the output cleaner and more focused.