### PR TITLE
fix(eslint): resolve @typescript-eslint/no-unused-vars errors

### DIFF
--- a/__fixtures__/core.ts
+++ b/__fixtures__/core.ts
@@ -6,7 +6,7 @@ export const error = vi.fn<typeof core.error>()
 export const info = vi.fn<typeof core.info>()
 export const getInput = vi
   .fn<typeof core.getInput>()
-  .mockImplementation((name, options) => {
+  .mockImplementation((name) => {
     const key = `INPUT_${name.replace(/ /g, '_').toUpperCase()}`
     return process.env[key] || ''
   })

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -53,7 +53,7 @@ describe('run: pr', () => {
           path.join(__dirname, 'testdata/audit/success.txt')
         ),
         status: 0,
-        run: (auditLevel: string): Promise<void> => {
+        run: (): Promise<void> => {
           return Promise.resolve(void 0)
         },
         foundVulnerability: (): boolean => {
@@ -78,7 +78,7 @@ describe('run: pr', () => {
           path.join(__dirname, 'testdata/audit/error.txt')
         ),
         status: 1,
-        run: (auditLevel: string): Promise<void> => {
+        run: (): Promise<void> => {
           return Promise.resolve(void 0)
         },
         foundVulnerability: (): boolean => {
@@ -105,7 +105,7 @@ describe('run: pr', () => {
           path.join(__dirname, 'testdata/audit/error.txt')
         ),
         status: 1,
-        run: (auditLevel: string): Promise<void> => {
+        run: (): Promise<void> => {
           return Promise.resolve(void 0)
         },
         foundVulnerability: (): boolean => {
@@ -147,7 +147,7 @@ describe('run: issue', () => {
           path.join(__dirname, 'testdata/audit/error.txt')
         ),
         status: 1,
-        run: (auditLevel: string): Promise<void> => {
+        run: (): Promise<void> => {
           return Promise.resolve(void 0)
         },
         foundVulnerability: (): boolean => {


### PR DESCRIPTION
Fixed ESLint errors related to unused variables by removing them from the codebase.

## Changes

1. Removed unused `options` parameter from `mockImplementation` in `__fixtures__/core.ts`
2. Removed unused `auditLevel` parameter from multiple `run` functions in `__tests__/main.test.ts`

These changes ensure compliance with the `@typescript-eslint/no-unused-vars` rule, which helps maintain cleaner and more maintainable code by eliminating unused variables.