### PR TITLE
fix(ci): run coveralls upload only on ubuntu-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,9 @@ jobs:
         run: |
           npm ci
           npm run test:coverage
-      - uses: coverallsapp/github-action@master
+      - name: Upload coverage to Coveralls
+        if: matrix.os == 'ubuntu-latest'
+        uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Changes

- Modified the test workflow to run Coveralls upload only on the `ubuntu-latest` runner
- This prevents duplicate coverage reports in multi-OS test environments
- Ensures consistent test reporting by running coverage upload from a single environment

## Why this change is needed

- The current configuration attempts to upload coverage reports from all test environments (ubuntu-latest, windows-latest, macos-latest)
- This can lead to duplicate or conflicting coverage reports in Coveralls
- By limiting the upload to ubuntu-latest, we maintain consistent reporting while still testing across multiple platforms

## Testing

- [x] Verified that the workflow runs successfully on all platforms
- [x] Confirmed that coverage is only uploaded from the ubuntu-latest runner
- [x] Ensured that test results are still collected from all platforms