### PR TITLE
fix: add tslib dev dependency to resolve rollup build error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "prettier": "^3.5.3",
         "rollup": "^4.41.1",
         "ts-node": "^10.9.2",
+        "tslib": "^2.8.1",
         "typescript": "^5.8.3",
         "vite": "^6.3.5",
         "vitest": "^3.1.2"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "prettier": "^3.5.3",
     "rollup": "^4.41.1",
     "ts-node": "^10.9.2",
+    "tslib": "^2.8.1",
     "typescript": "^5.8.3",
     "vite": "^6.3.5",
     "vitest": "^3.1.2"


### PR DESCRIPTION
Fixed the rollup build error by adding the missing tslib dependency.

## Problem

The `@rollup/plugin-typescript` plugin was failing with the error:
```
@rollup/plugin-typescript: Could not find module 'tslib', which is required by this plugin. Is it installed?
```

## Solution

- Added `tslib ^2.8.1` as a dev dependency
- The tslib library provides TypeScript runtime helpers required by the rollup TypeScript plugin

## Testing

- ✅ `npm run package` now completes successfully
- ✅ `npm run all` passes all pipeline steps (format, lint, test, package)
- ✅ All 20 tests pass with coverage report
- ✅ Build generates `dist/index.js` correctly

Fixes the rollup build pipeline and ensures CI/CD workflows will work properly.