### PR TITLE
ci: sync dist/ on pull requests instead of after merge

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: install dependencies
         run: npm ci
       - uses: oke-py/npm-audit-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
@@ -39,6 +41,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
@@ -59,6 +63,8 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -1,17 +1,27 @@
 # In TypeScript actions, `dist/` is a special directory. When you reference
-# an action with the `uses:` property, `dist/index.js` is the code that will be
-# run. For this project, the `dist/index.js` file is transpiled from other
+# an action with the `uses:` property, `dist/index.js` is the code that will
+# be run. For this project, the `dist/index.js` file is transpiled from other
 # source files. This workflow ensures the `dist/` directory contains the
 # expected transpiled code.
 #
-# On pushes to `main`, it rebuilds `dist/` and auto-commits updates when needed.
+# It runs on pull requests: it rebuilds `dist/` and, when the result
+# differs, commits it back to the PR branch. This keeps every commit on
+# `main` releasable without a post-merge fixup commit.
+#
+# Notes:
+# - Commits pushed with GITHUB_TOKEN do not trigger new workflow runs.
+#   Re-run the PR checks manually if they need to cover the dist commit.
+# - For PRs from forks this workflow cannot push; the final check fails
+#   instead, and the author should run `npm run bundle` and commit the
+#   result.
 name: "update dist/index.js"
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
 
+# `contents: write` is required to push dist updates to the PR branch.
+# Setting it explicitly also grants write access on Dependabot-triggered
+# runs, which default to a read-only token.
 permissions:
   contents: write
 
@@ -24,6 +34,9 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Setup Node.js
         id: setup-node
@@ -40,30 +53,19 @@ jobs:
         id: build
         run: npm run package
 
-      - name: Detect dist/ changes
-        id: dist-changes
-        run: |
-          if [ ! -d dist/ ]; then
-            echo "Expected dist/ directory does not exist."
-            exit 1
-          fi
-          if git diff --ignore-space-at-eol --text --quiet -- dist/; then
-            echo "changes=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changes=true" >> "$GITHUB_OUTPUT"
-          fi
-
+      # Signal to Dependabot that its PRs are still safe to operate on
+      # after this workflow pushes a dist update commit.
       - name: Commit dist/ (if changed)
-        if: >-
-          ${{
-            steps.dist-changes.outputs.changes == 'true' &&
-            !contains(github.event.head_commit.message, '[skip ci]') &&
-            !contains(github.event.head_commit.message, '[ci skip]') &&
-            !contains(github.event.head_commit.message, '[no ci]') &&
-            !contains(github.event.head_commit.message, '[skip actions]') &&
-            !contains(github.event.head_commit.message, '[actions skip]')
-          }}
+        id: commit-dist
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
-          commit_message: "chore: update dist [skip ci]"
+          commit_message: >-
+            ${{ github.event.pull_request.user.login == 'dependabot[bot]'
+                && 'chore: update dist [dependabot skip]'
+                || 'chore: update dist' }}
           file_pattern: dist/**
+
+      - name: Check dist/ is up to date
+        id: check-dist
+        run: git diff --ignore-space-at-eol --text --exit-code -- dist/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,8 +50,11 @@ npm run bundle
 - Bundling is done via Rollup
 - `npm run package` builds `dist/index.js`
 - The action runs from `dist/index.js`
-- After merging to `main`, the `update-dist` workflow updates `dist/index.js`
-- Create releases from the commit that includes the updated `dist/index.js`
+- The `update dist/index.js` workflow rebuilds `dist/` on pull requests
+  and commits changes back to the PR branch, so `dist/` stays in sync on
+  every commit on `main`
+- For PRs from forks the workflow cannot push; run `npm run bundle` and
+  commit the result instead
 
 ## Release Process
 
@@ -66,8 +69,6 @@ The same flow covers major, minor, and patch releases.
    `package.json`, `package-lock.json`, and `CHANGELOG.md`.
 1. For major releases, update usage references to the new major tag
    (README and workflows) before merging the release PR.
-1. Confirm the `update-dist` workflow has finished so that
-   `dist/index.js` on `main` is up to date.
 1. Merge the release PR. This creates the version tag and the GitHub
    Release, and moves the major tag (e.g. `v4`).
 
@@ -93,7 +94,10 @@ Notes:
 ## CI Expectations
 
 - PRs must pass formatting, linting, tests, and packaging checks.
-- PRs may or may not update `dist/`, depending on the workflow policy.
+- The `update dist/index.js` workflow keeps `dist/` in sync on the PR
+  branch. Commits it pushes do not trigger new workflow runs
+  (a `GITHUB_TOKEN` limitation); re-run the PR checks manually if they
+  need to cover the dist commit.
 - The `Licensed` workflow (licensee/licensed-ci) updates and verifies
   cached dependency license metadata on PRs and pushes to `main`.
 


### PR DESCRIPTION
## What changed

- The `update dist/index.js` workflow now runs on `pull_request`: it rebuilds
  `dist/` and commits any changes back to the PR branch, then verifies
  `dist/` is in sync. The post-merge auto-commit on `main` is removed.
- Dependabot PR commits use a `[dependabot skip]` prefix so Dependabot keeps
  operating on its PRs. PRs from forks cannot be pushed to; the final check
  fails and the author runs `npm run bundle` instead.
- `persist-credentials: false` on checkouts in the `test` and `daily`
  workflows, which never push.
- `DEVELOPMENT.md` updated: the release process no longer needs the
  "wait for update-dist" step because every commit on `main` keeps `dist/`
  in sync.

## Why

With release-please, the release tag points at the release PR merge commit.
The old post-merge dist commit left a window where a release could tag a
stale bundle. Building dist at PR time closes that race and removes a manual
verification step from the release process.

## Notes for the reviewer

- Commits pushed with `GITHUB_TOKEN` do not trigger new workflow runs; if a
  dist commit lands on a PR, re-run checks manually when needed (documented
  in DEVELOPMENT.md).
- This PR itself exercises the new workflow (it should build dist, find no
  diff, and pass the check).
- Verified locally that `npm ci && npm run package` reproduces the committed
  `dist/` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)