### PR TITLE
ci: add zizmor workflow audit and fix its findings

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -21,7 +21,9 @@ jobs:
           persist-credentials: false
       - name: install dependencies
         run: npm ci
-      - uses: oke-py/npm-audit-action@v4
+      # Intentionally unpinned: dogfoods the latest released major tag of
+      # this repository's own action.
+      - uses: oke-py/npm-audit-action@v4 # zizmor: ignore[unpinned-uses]
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           issue_assignees: oke-py

--- a/.github/workflows/git-tag.yml
+++ b/.github/workflows/git-tag.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: check out repository code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # The push below authenticates via the tokenized remote URL.
+          persist-credentials: false
       - name: git config
         run: |
           git config --global user.name "${GITHUB_ACTOR}"

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -34,13 +34,19 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # licensed-ci pushes through its own tokenized remote, so the
+          # checkout credentials are not needed.
+          persist-credentials: false
 
-      - name: Setup Node.js
+      # npm caching is intentionally not enabled here: this workflow pushes
+      # commits, so a poisoned cache could end up in the repository. The
+      # zizmor ignore is for a false positive (caching is already off).
+      - name: Setup Node.js # zizmor: ignore[cache-poisoning]
         id: setup-node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
-          cache: npm
 
       - name: Install Dependencies
         id: npm-ci

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Checkout
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # The push below authenticates via the tokenized remote URL.
+          persist-credentials: false
 
       - name: Update major tag
         if: ${{ steps.release.outputs.release_created }}
@@ -39,8 +42,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email \
             "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
           git tag -f "v${MAJOR}" "${RELEASE_SHA}"
           git push -f origin "v${MAJOR}"
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAJOR: ${{ steps.release.outputs.major }}
           RELEASE_SHA: ${{ steps.release.outputs.sha }}

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -31,7 +31,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      # Credential persistence is required: git-auto-commit-action pushes
+      # the dist update using the checkout credentials.
+      - name: Checkout # zizmor: ignore[artipacked]
         id: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,34 @@
+# Static security audit of the GitHub Actions workflows in this repository
+# using zizmor. Detects template injection, unpinned actions, excessive
+# permissions, credential persistence, and other workflow weaknesses.
+# See: https://docs.zizmor.sh
+
+name: zizmor
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Audit workflows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # advanced-security is disabled so findings fail this check directly
+      # instead of being uploaded to the code scanning dashboard.
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false


### PR DESCRIPTION
## What changed

- New `zizmor` workflow ([zizmorcore/zizmor-action](https://github.com/zizmorcore/zizmor-action), SHA-pinned) runs on PRs and pushes to `main` in plain mode: any workflow security finding fails the check. This locks in the recent hardening (SHA pinning, least-privilege permissions, credential handling) against regressions.
- Fixed everything zizmor flagged in the existing workflows:
  - `git-tag`, `release-please`: `persist-credentials: false`; pushes now authenticate via a tokenized remote URL (`x-access-token`).
  - `licensed`: `persist-credentials: false` (licensed-ci configures its own tokenized remote — verified in its source) and npm caching disabled because the workflow pushes commits (cache-poisoning surface).
  - `daily`: inline `zizmor: ignore[unpinned-uses]` for `oke-py/npm-audit-action@v4`, which intentionally dogfoods the latest released tag.
  - `update-dist`: inline `zizmor: ignore[artipacked]`; git-auto-commit-action requires the checkout credentials to push dist updates.

## Verification

Ran zizmor 1.26.1 locally against `.github/workflows/`: `No findings to report.` (3 ignored with inline comments, 22 suppressed by default personas). This PR also exercises the new check on itself.

## Notes

- zizmor's version floats (`version: latest` default) so new audits apply automatically; the action itself is SHA-pinned and tracked by Dependabot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)