### PR TITLE
chore: reference v5 and complete the 5.0.0 changelog entry

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm ci
       # Intentionally unpinned: dogfoods the latest released major tag of
       # this repository's own action.
-      - uses: oke-py/npm-audit-action@v4 # zizmor: ignore[unpinned-uses]
+      - uses: oke-py/npm-audit-action@v5 # zizmor: ignore[unpinned-uses]
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           issue_assignees: oke-py
@@ -49,7 +49,7 @@ jobs:
   #         npm-windows-upgrade --npm-version latest --no-prompt
   #     - name: install dependencies
   #       run: npm ci
-  #     - uses: oke-py/npm-audit-action@v4
+  #     - uses: oke-py/npm-audit-action@v5
   #       with:
   #         github_token: ${{ secrets.GITHUB_TOKEN }}
   #         issue_assignees: oke-py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### ⚠ BREAKING CHANGES
 
-* the github_context input has been removed. The action now reads event information from the runner environment. Remove
+* the github_context input has been removed. The action now reads event information from the runner environment. Remove `github_context: ${{ toJson(github) }}` from your workflow if present.
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: install dependencies
         run: npm ci
-      - uses: oke-py/npm-audit-action@v4
+      - uses: oke-py/npm-audit-action@v5
         with:
           audit_level: moderate
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

- Bump `oke-py/npm-audit-action@v4` to `@v5` in the daily dogfooding workflow (`.github/workflows/daily.yml`, including the disabled Windows job) and the README example workflow.
- Complete the truncated BREAKING CHANGES sentence in the 5.0.0 CHANGELOG entry: release-please only picked up the first line of the multi-line `BREAKING CHANGE:` commit footer, cutting the sentence off at "Remove". The GitHub Release notes were already fixed by editing the release PR body before merge; this aligns the committed CHANGELOG.md with them.

## Why

Follow-up to #360 / the v5.0.0 release (#361), so the repo dogfoods the new major version and the changelog reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)