### PR TITLE
ci: remove GitHub context dump from the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,10 +58,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -92,10 +88,6 @@ jobs:
   #       node: [24]
   #   runs-on: windows-latest
   #   steps:
-  #   - name: Dump GitHub context
-  #     env:
-  #       GITHUB_CONTEXT: ${{ toJson(github) }}
-  #     run: echo "$GITHUB_CONTEXT"
   #   - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
   #   - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
   #     with:


### PR DESCRIPTION
## What

Removes the "Dump GitHub context" debug step (`echo` of `${{ toJson(github) }}`) from the `test` job in `.github/workflows/test.yml`, and the same step from the commented-out `test-on-windows` job for consistency.

## Why

Follow-up to #343 / #360: the issue's concern was handing the entire `github` context to code that doesn't need it. This debug step is the same pattern — it serializes the whole context into the job log (the token is masked by the runner, but nothing in the workflow consumes the dump anymore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)