### PR TITLE
ci: run npm audit workflows on ubuntu-slim and modernize the README example

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-slim, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         node: [24]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-slim, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -29,7 +29,7 @@ jobs:
           npm run lint
           npm run test:coverage
       - name: Upload coverage to Coveralls
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-slim'
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         node: [24]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-slim, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/README.md
+++ b/README.md
@@ -67,13 +67,15 @@ on:
 jobs:
   scan:
     name: npm audit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: install dependencies
         run: npm ci
       - uses: oke-py/npm-audit-action@v5


### PR DESCRIPTION
## Summary
- Switch the `build`, `test` (test.yml), and daily `scan` (daily.yml) jobs from `ubuntu-latest` to `ubuntu-slim`. These jobs only need Node.js, npm, and Git, which the [ubuntu-slim image](https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md) provides (Node.js 24 / npm 11 on Ubuntu 24.04), so they benefit from the faster, lighter image. The Coveralls upload condition (`matrix.os == 'ubuntu-latest'`) is updated accordingly.
- Workflows that rely on heavier tooling stay on `ubuntu-latest`: zizmor (runs a Docker container) and licensed, plus the release plumbing.
- README example workflow modernized to match this repository's own workflows: `actions/checkout@v7` (was `@v6`), `persist-credentials: false`, and `runs-on: ubuntu-slim`.

## Testing
- The updated `build` and `test` jobs run on `ubuntu-slim` in this PR's own CI, which verifies the image has everything the action needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)