### PR TITLE
docs: state the action's scope and document the monorepo matrix pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ GitHub Action that runs `npm audit` and reports vulnerabilities.
 
 ![Issue example](https://github.com/oke-py/npm-audit-action/blob/main/issue.png)
 
+## Scope: when to use this action
+
+This action runs `npm audit` as a CI gate and reports the results. It is intentionally small:
+
+- **No external service or token required** — nothing leaves GitHub
+- **Blocks vulnerabilities at pull request time**, before they are merged
+- **Detection and reporting only**
+
+It does not aim to replace dedicated tools, and works well alongside them:
+
+- For automated remediation (dependency update PRs), use [Dependabot security updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates) or `npm audit fix`
+- For deeper analysis such as reachability, license compliance, or container scanning, use a dedicated service like Snyk
+
 ## Usage
 
 ### Permissions
@@ -90,6 +103,38 @@ jobs:
           dedupe_issues: true
           dedupe_comments: true
 ```
+
+### Monorepos
+
+`working_directory` accepts a single directory. To audit multiple packages, use a [matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs):
+
+```yaml
+jobs:
+  scan:
+    strategy:
+      matrix:
+        workdir: [packages/a, packages/b, tools/c]
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: install dependencies
+        run: npm ci
+        working-directory: ${{ matrix.workdir }}
+      - uses: oke-py/npm-audit-action@v5
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          working_directory: ${{ matrix.workdir }}
+          issue_title: 'npm audit found vulnerabilities (${{ matrix.workdir }})'
+          dedupe_issues: true
+```
+
+Including the directory in `issue_title` keeps `dedupe_issues` working per package.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a **Scope: when to use this action** section to the README, positioning the action as a small `npm audit` CI gate — no external service or token, blocks vulnerabilities at pull request time, detection and reporting only — and pointing to Dependabot security updates / `npm audit fix` for remediation and to dedicated scanners for deeper analysis. This declares the project scope explicitly (context: #4).
- Add a **Monorepos** section documenting the `strategy.matrix` pattern for auditing multiple packages, including the tip of embedding the directory in `issue_title` so `dedupe_issues` works per package. This addresses the use case of #72 without adding glob/array handling to the action itself.

Refs #4, #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)