### PR TITLE
ci: do not fail the build when the Coveralls upload fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,8 @@ jobs:
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Coverage is informational; a Coveralls outage must not fail CI
+          fail-on-error: false
 
   build-on-windows:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
- Set `fail-on-error: false` on the Coveralls upload step in the `build` job.
- Coverage reporting is informational; a Coveralls outage should not block CI. The ongoing Coveralls 504 gateway timeouts failed the `build (ubuntu-slim)` job on #378 and #379 even though every test passed — with this setting those runs would have stayed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)