### PR TITLE
ci: migrate coverage reporting from Coveralls to octocov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,10 @@ jobs:
       matrix:
         os: [ubuntu-slim, macos-latest]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write # octocov pushes the coverage badge to the default branch
+      pull-requests: write # octocov posts the coverage report comment
+      actions: read # octocov reads previous reports from artifacts
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -28,13 +32,9 @@ jobs:
           npm run format:check
           npm run lint
           npm run test:coverage
-      - name: Upload coverage to Coveralls
+      - name: Report coverage with octocov
         if: matrix.os == 'ubuntu-slim'
-        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Coverage is informational; a Coveralls outage must not fail CI
-          fail-on-error: false
+        uses: k1LoW/octocov-action@1a4952bd39550c218d97941a2712a19e1e4e3731 # v1.5.1
 
   build-on-windows:
     runs-on: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           npm run test:coverage
       - name: Report coverage with octocov
         if: matrix.os == 'ubuntu-slim'
-        uses: k1LoW/octocov-action@1a4952bd39550c218d97941a2712a19e1e4e3731 # v1.5.1
+        uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1.5.1
 
   build-on-windows:
     runs-on: windows-latest

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,0 +1,23 @@
+coverage:
+  paths:
+    - coverage/lcov.info
+  # Fixed threshold: fail the build when coverage drops below 90%.
+  # Deliberately not diff-based; small fluctuations must not fail CI.
+  acceptable: 90%
+  badge:
+    path: docs/coverage.svg
+comment:
+  if: is_pull_request
+  updatePrevious: true
+summary:
+  if: true
+report:
+  if: is_default_branch
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+diff:
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+push:
+  if: is_default_branch
+  message: 'chore: update coverage badge by octocov [skip ci]'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # npm audit action
 
-[![Coverage Status](https://coveralls.io/repos/github/oke-py/npm-audit-action/badge.svg?branch=main)](https://coveralls.io/github/oke-py/npm-audit-action?branch=main)
+![Coverage](docs/coverage.svg)
 
 GitHub Action that runs `npm audit` and reports vulnerabilities.
 

--- a/docs/coverage.svg
+++ b/docs/coverage.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="133.5" height="20" role="img" aria-label="octocov::badge">
+    <title>octocov::badge</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="133.5" height="20" rx="3" fill="#fff"/>
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="83.5" height="20" fill="#24292E"/>
+        <rect x="83.5" width="50" height="20" fill="#97CA00"/>
+        <rect width="133.5" height="20" fill="url(#s)"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        
+        <image x="5" y="3" width="14" height="14" xlink:href="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxuczpzZXJpZj0iaHR0cDovL3d3dy5zZXJpZi5jb20vIiBzdHlsZT0iZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjI7Ij4KICAgIDxwYXRoIGQ9Ik05NS44ODEsMzAuODk5TDY5LjEwMSw0LjExOUwzMC44OTksNC4xMTlMNC4xMTksMzAuODk5TDQuMTE5LDY5LjEwMUwzMC44OTksOTUuODgxTDY5LjEwMSw5NS44ODFMOTUuODgxLDY5LjEwMUw5NS44ODEsMzAuODk5Wk02My4xMTQsMTguNTYzTDgxLjQzNywzNi44ODZMODEuNDM3LDYzLjExNEw2My4xMTQsODEuNDM3TDM2Ljg4Niw4MS40MzdMMTguNTYzLDYzLjExNEwxOC41NjMsMzYuODg2TDM2Ljg4NiwxOC41NjNMNjMuMTE0LDE4LjU2M1oiIHN0eWxlPSJmaWxsOnJnYigxNDksMTU3LDE2NSk7Ij48L3BhdGg+Cjwvc3ZnPg=="/>
+        
+        <text aria-hidden="true" x="495" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">coverage</text>
+        <text x="495" y="140" transform="scale(.1)" fill="#fff">coverage</text>
+        <text aria-hidden="true" x="1085" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">96.1%</text>
+        <text x="1085" y="140" transform="scale(.1)" fill="#fff">96.1%</text>
+    </g>
+</svg>


### PR DESCRIPTION
## Summary
- Replace the Coveralls upload with [octocov](https://github.com/k1LoW/octocov), which needs **no external service or token** — consistent with the scope this action declares for itself in the README.
- **Fixed 90% coverage threshold** (`coverage.acceptable: 90%`): CI fails only when coverage drops below 90%, replacing the delta-based judgement that fluctuated and caused unnecessary failures. The PR comment still shows a diff against the last main report, but it is informational only.
- **Self-hosted README badge**: octocov regenerates `docs/coverage.svg` on pushes to main and commits it with a `[skip ci]` message (the only automated direct push to main; sanctioned for CI-generated badge updates). The initial badge (96.1%, lcov line coverage) is included so the README renders immediately after merge.
- octocov also writes a job summary and stores reports in GitHub Actions artifacts for the PR diff.
- The `build` job gets job-level permissions: `contents: write` (badge push), `pull-requests: write` (coverage comment), `actions: read` (artifact reports). `k1LoW/octocov-action` is pinned by SHA (v1.5.1).

## Reviewer notes
- The Coveralls integration and any `COVERALLS_*` secrets can be removed from the repo settings after merge.
- The badge push relies on main's branch protection not requiring PRs for github-actions; verified that this is the case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)