### PR TITLE
ci: add code-to-test-ratio and test execution time badges

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -6,6 +6,21 @@ coverage:
   acceptable: 90%
   badge:
     path: docs/coverage.svg
+# Informational only (no acceptable threshold): lines of test code per
+# line of product code
+codeToTestRatio:
+  code:
+    - src/**/*.ts
+  test:
+    - __tests__/**/*.ts
+    - __fixtures__/**/*.ts
+    # the workdir fixture contains a committed node_modules
+    - '!__tests__/testdata/**'
+  badge:
+    path: docs/ratio.svg
+testExecutionTime:
+  badge:
+    path: docs/time.svg
 comment:
   if: is_pull_request
   updatePrevious: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # npm audit action
 
-![Coverage](docs/coverage.svg)
+![Coverage](docs/coverage.svg) ![Code to Test Ratio](docs/ratio.svg) ![Test Execution Time](docs/time.svg)
 
 GitHub Action that runs `npm audit` and reports vulnerabilities.
 

--- a/docs/ratio.svg
+++ b/docs/ratio.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="168.5" height="20" role="img" aria-label="octocov::badge">
+    <title>octocov::badge</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="168.5" height="20" rx="3" fill="#fff"/>
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="124.5" height="20" fill="#24292E"/>
+        <rect x="124.5" width="44" height="20" fill="#97CA00"/>
+        <rect width="168.5" height="20" fill="url(#s)"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        
+        <image x="5" y="3" width="14" height="14" xlink:href="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxuczpzZXJpZj0iaHR0cDovL3d3dy5zZXJpZi5jb20vIiBzdHlsZT0iZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjI7Ij4KICAgIDxwYXRoIGQ9Ik05NS44ODEsMzAuODk5TDY5LjEwMSw0LjExOUwzMC44OTksNC4xMTlMNC4xMTksMzAuODk5TDQuMTE5LDY5LjEwMUwzMC44OTksOTUuODgxTDY5LjEwMSw5NS44ODFMOTUuODgxLDY5LjEwMUw5NS44ODEsMzAuODk5Wk02My4xMTQsMTguNTYzTDgxLjQzNywzNi44ODZMODEuNDM3LDYzLjExNEw2My4xMTQsODEuNDM3TDM2Ljg4Niw4MS40MzdMMTguNTYzLDYzLjExNEwxOC41NjMsMzYuODg2TDM2Ljg4NiwxOC41NjNMNjMuMTE0LDE4LjU2M1oiIHN0eWxlPSJmaWxsOnJnYigxNDksMTU3LDE2NSk7Ij48L3BhdGg+Cjwvc3ZnPg=="/>
+        
+        <text aria-hidden="true" x="700" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">code to test ratio</text>
+        <text x="700" y="140" transform="scale(.1)" fill="#fff">code to test ratio</text>
+        <text aria-hidden="true" x="1465" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">1:2.0</text>
+        <text x="1465" y="140" transform="scale(.1)" fill="#fff">1:2.0</text>
+    </g>
+</svg>


### PR DESCRIPTION
## Summary
- Add `codeToTestRatio` (informational, no threshold) and `testExecutionTime` badges to `.octocov.yml` and the README, alongside the coverage badge.
- The ratio counts `src/` as code and `__tests__/` + `__fixtures__/` as test, **excluding `__tests__/testdata/`** — the workdir fixture contains a committed `node_modules` (~29k lines of TypeScript lib typings) that inflated the ratio to 1:36. With the exclusion the ratio is a plausible **1:2.0** (946 code lines vs ~1.9k test lines).
- `docs/ratio.svg` is generated locally and committed so it renders immediately. `docs/time.svg` can only be measured on CI, so the README reference will show as broken for the few minutes until the first post-merge run on main, when octocov generates and commits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)