### PR TITLE
ci: add a standalone typecheck step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
           npm ci
           npm run format:check
           npm run lint
+          npm run typecheck
           npm run test:coverage
       - name: Report coverage with octocov
         if: matrix.os == 'ubuntu-slim'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ This repository is a GitHub Action that runs `npm audit` and reports findings by
 npm ci
 npm run format:write
 npm run lint
+npm run typecheck
 npm run test
 npm run test:coverage
 npm run package

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,6 +20,7 @@ npm ci
 npm run format:write
 npm run format:check
 npm run lint
+npm run typecheck
 npm run test
 npm run test:coverage
 npm run package
@@ -32,6 +33,9 @@ npm run bundle
 - Strict type checking is enabled in `tsconfig.base.json`
 - Module settings use `NodeNext`
 - Target runtime is `ES2022`
+- `npm run typecheck` runs `tsc --noEmit` over `src/`. Keep it independent of
+  the bundler so type errors are caught even if the bundler stops type
+  checking
 
 ## Formatting and Linting
 

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
     "format:write": "npx biome format --write .",
     "format:check": "npx biome check --formatter-enabled=true --linter-enabled=false .",
     "lint": "npx biome lint .",
+    "typecheck": "npx tsc --noEmit",
     "package": "npx rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
     "prepare": "husky",
     "test": "vitest --run",
     "test:coverage": "vitest --run --coverage",
-    "all": "npm run format:write && npm run lint && npm run test:coverage && npm run package"
+    "all": "npm run format:write && npm run lint && npm run typecheck && npm run test:coverage && npm run package"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
First step of the TypeScript 7 migration (#389).

## Problem

Type checking currently happens only as a side effect of `@rollup/plugin-typescript` during `npm run package`. There is no standalone `tsc` invocation anywhere in `package.json` or the workflows, so:

- no CI job fails on a type error by itself — `test.yml` runs format/lint/test only
- replacing the bundler with any transpile-only tool (swc, rolldown, esbuild) would silently drop type checking altogether

That second point blocks the rest of the migration, so this comes first.

## Changes

- Add `"typecheck": "npx tsc --noEmit"` and include it in `npm run all`
- Run `npm run typecheck` in the `build` job of `test.yml`
- Document it in `DEVELOPMENT.md` and `AGENTS.md`

Scope matches what the bundler compiles today: `tsconfig.json` includes `src` only, so `__tests__` remains unchecked. Widening that is a separate change.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run test`, `npm run package` all exit 0
- `git diff --exit-code -- dist/` is clean — no bundle change
- Sanity-checked that the script is not a no-op: a deliberate `const x: number = "s"` in `src/workdir.ts` makes it exit 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)