### PR TITLE
docs: document how to release build-only changes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -80,6 +80,21 @@ The same flow covers major, minor, and patch releases.
 
 Notes:
 
+- Only `fix:`, `feat:`, and breaking changes bump the version. Commits
+  typed `build:`, `ci:`, `chore:`, or `docs:` land on `main` without
+  producing a release PR, so the rebuilt `dist/` sits unreleased until the
+  next `fix:` or `feat:`.
+- To release such changes on their own, add a `Release-As:` footer to the
+  commit that lands on `main`, which makes release-please cut that exact
+  version:
+
+  ```
+  Release-As: 5.4.1
+  ```
+
+  This is worth doing when `dist/` changed materially — for example after a
+  bundler swap — so that any regression is attributable to a single release
+  rather than shipping alongside a feature.
 - The `release-please` workflow authenticates with the
   `RELEASE_PLEASE_TOKEN` repository secret, a fine-grained PAT with
   Contents and Pull requests read/write access to this repository.


### PR DESCRIPTION
Follow-up to the TypeScript 7 migration (#389). **Merging this PR cuts release 5.4.1.**

## Why a release is needed

None of the three migration PRs produced a release PR. They were typed `ci:` (#390) and `build:` (#391, #386), and release-please only bumps on `fix:`, `feat:`, and breaking changes. That is correct behaviour, but it means `v5` / `v5.4.0` still points at `8809ddd` — so everyone using `@v5` is running the **old rollup + TypeScript 6 bundle**, while `main` carries the rolldown one.

## Why release it separately rather than waiting

The CI `test` job executes the built `dist/` through `uses: ./`, but with `create_issues: false` and `create_pr_comments: false`. Both default to `true` in `action.yml`, so the Octokit paths — the default behaviour for real users — have **no end-to-end coverage against the built bundle**. Unit tests cover them against `src/` with mocks.

That is precisely where a bundler swap is most likely to bite: `@octokit/rest` CommonJS interop moved from `@rollup/plugin-commonjs` to rolldown's built-in handling.

Shipping the bundler change on its own means any regression is attributable to exactly one release and users can pin back to 5.4.0. Bundled into a future `feat:` release, the same bug would be far harder to isolate.

## Changes

- `DEVELOPMENT.md`: document that `build:`/`ci:`/`chore:`/`docs:` commits do not produce a release, and document the `Release-As:` footer as the way to cut one for build-only changes
- The commit carries `Release-As: 5.4.1`

## Merging

Keep the `Release-As: 5.4.1` footer in the squash commit body — release-please reads it from the commit that lands on `main`. Merging opens a release PR for 5.4.1; merging *that* creates the tag, the GitHub Release, and moves the `v5` major tag onto the rolldown bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)