### PR TITLE
ci: show the Build System section in the changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,20 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "docs", "section": "Documentation" },
+        { "type": "build", "section": "Build System" },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true }
+      ]
     }
   }
 }


### PR DESCRIPTION
Merge this **before** the 5.4.1 release PR (#393).

## Problem

#393 currently lists only this:

```
### Documentation
* document how to release build-only changes (#392)
```

That release exists to ship `dist/index.js` rebuilt by a different bundler — 25% smaller, produced by rolldown instead of rollup. None of that appears, because release-please hides `build:` by default. A user reading the changelog would reasonably conclude 5.4.1 is documentation-only.

For this repository `dist/` *is* the product, so changes to how it is produced are user-relevant and belong in the changelog.

## Changes

`changelog-sections` in `release-please-config.json`, with `build` visible.

`ci:` stays hidden deliberately: it only touches this repository's own workflows and dev scripts, which never reach users. #390 is a good example — it added a `typecheck` script and a CI step, with zero effect on the published action.

Note that `changelog-sections` **replaces** the defaults rather than merging with them, so the full list is spelled out; omitting it would silently drop Features, Bug Fixes and Documentation.

## Effect on #393

Release-please regenerates an open release PR when `main` moves, so #393 should pick up a Build System section covering:

- #391 — `build: replace rollup with rolldown`
- #386 — `build(deps-dev): bump typescript from 6.0.3 to 7.0.2`
- #388 — `build(deps): bump the actions-minor group`

I will confirm the regenerated content before you merge #393.

## Tradeoff

Dependabot's `build(deps)` commits now appear in the changelog too. That is the cost of recording bundler and toolchain changes; if it turns out too noisy, the `deps` scope can be split out later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)