### PR TITLE
chore: update biome.json $schema to 2.5.5

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": [
       "**",


### PR DESCRIPTION
## Summary
- Bump the `$schema` URL in `biome.json` from 2.5.2 to 2.5.5 to match the `@biomejs/biome` version in `package.json` / `package-lock.json`.

## Test plan
- `npx biome check biome.json` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)