### PR TITLE
test: add end-to-end tests for the Octokit paths in the built bundle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,10 @@ jobs:
           npm run lint
           npm run typecheck
           npm run test:coverage
+      - name: Run end-to-end tests against a freshly built bundle
+        run: |
+          npm run package
+          npm run test:e2e
       - name: Report coverage with octocov
         if: matrix.os == 'ubuntu-slim'
         uses: k1LoW/octocov-action@a167dc0dee441b7ffc45e1b862ab55ec0d87f278 # v1.5.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ This repository is a GitHub Action that runs `npm audit` and reports findings by
 - `src/main.ts`: Entry point
 - `src/issue.ts`, `src/pr.ts`: Issue and PR comment logic
 - `dist/index.js`: Bundled output used by GitHub Actions
-- `__tests__/`: Vitest tests
+- `__tests__/`: Vitest tests; `__tests__/e2e/` runs the built bundle against a
+  mock GitHub API (`npm run test:e2e`, needs `npm run package` first)
 
 ## Local Commands
 
@@ -22,6 +23,7 @@ npm run typecheck
 npm run test
 npm run test:coverage
 npm run package
+npm run test:e2e
 ```
 
 ## Guardrails

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,7 +10,7 @@
 - `action.yml`: Action metadata and inputs/outputs
 - `src/`: TypeScript source code
 - `dist/`: Bundled action output (committed)
-- `__tests__/`: Vitest tests
+- `__tests__/`: Vitest tests (`__tests__/e2e/`: end-to-end tests of `dist/`)
 - `__fixtures__/`: test fixtures
 
 ## Common Commands
@@ -23,6 +23,7 @@ npm run lint
 npm run typecheck
 npm run test
 npm run test:coverage
+npm run test:e2e
 npm run package
 npm run all
 npm run bundle
@@ -46,8 +47,14 @@ npm run bundle
 ## Testing
 
 - Uses Vitest
-- `npm run test` runs the test suite
+- `npm run test` runs the unit test suite
 - `npm run test:coverage` generates coverage in `coverage/`
+- `npm run test:e2e` runs the end-to-end tests in `__tests__/e2e/`, which
+  spawn the built `dist/index.js` against a local mock of the GitHub REST API
+  and a stub `npm`. Run `npm run package` first: they test the bundle, not
+  `src/`, and are the only tests that cover the `@octokit/rest` code paths
+  after bundling. They are excluded from `npm run test` and from coverage,
+  and are skipped on Windows (the `npm` stub is a POSIX shell script)
 
 ## Packaging
 

--- a/__tests__/e2e/bundle.test.ts
+++ b/__tests__/e2e/bundle.test.ts
@@ -1,0 +1,190 @@
+// End-to-end tests for the built bundle.
+//
+// These run `node dist/index.js` as a child process against a local mock of
+// the GitHub REST API, so they cover the `@octokit/rest` code paths as they
+// exist *after* bundling. Unit tests mock `@octokit/rest` at the module level
+// and by construction cannot catch bundling regressions.
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  auditDir,
+  bundlePath,
+  type MockApi,
+  type MockApiResponses,
+  runAction,
+  startMockApi
+} from './helpers'
+
+const REPORT_MARKER = '<!-- npm-audit-action -->'
+const RESOLVED_MARKER = '<!-- npm-audit-action:resolved -->'
+const ISSUE_TITLE = 'npm audit found vulnerabilities'
+const COMMENTS_PATH = '/repos/oke-py/npm-audit-action/issues/100/comments'
+const ISSUES_PATH = '/repos/oke-py/npm-audit-action/issues'
+
+const auditText = fs.readFileSync(path.join(auditDir, 'error.txt'), 'utf8')
+const reportBody = `\`\`\`\n${auditText}\n\`\`\``
+
+let api: MockApi | null = null
+
+async function withMockApi(responses?: MockApiResponses): Promise<MockApi> {
+  api = await startMockApi(responses)
+  return api
+}
+
+afterEach(async () => {
+  await api?.close()
+  api = null
+})
+
+// The stub `npm` is a POSIX shell script; the bundle itself is covered on
+// Windows by the `test-on-windows` job in test.yml.
+describe.skipIf(process.platform === 'win32')('dist/index.js', () => {
+  it('is built', () => {
+    expect(fs.existsSync(bundlePath)).toBe(true)
+  })
+
+  it('posts a pull request comment when vulnerabilities are found', async () => {
+    const mock = await withMockApi()
+
+    const result = await runAction({
+      apiUrl: mock.url,
+      eventName: 'pull_request',
+      eventFile: 'pull_request.json'
+    })
+
+    // fail_on_vulnerabilities defaults to true
+    expect(result.status).toBe(1)
+    expect(mock.requests).toHaveLength(1)
+    const [request] = mock.requests
+    expect(request.method).toBe('POST')
+    expect(request.path).toBe(COMMENTS_PATH)
+    expect(request.body.body).toBe(reportBody)
+    expect(request.authorization).toBe('token test-token')
+  })
+
+  it('calls no API when create_pr_comments is false', async () => {
+    const mock = await withMockApi()
+
+    const result = await runAction({
+      apiUrl: mock.url,
+      eventName: 'pull_request',
+      inputs: {
+        create_pr_comments: 'false',
+        fail_on_vulnerabilities: 'false'
+      }
+    })
+
+    expect(result.status).toBe(0)
+    expect(mock.requests).toHaveLength(0)
+  })
+
+  it('creates an issue on a push event when vulnerabilities are found', async () => {
+    const mock = await withMockApi()
+
+    const result = await runAction({
+      apiUrl: mock.url,
+      eventName: 'push',
+      inputs: {
+        issue_labels: 'security, audit',
+        issue_assignees: 'oke-py'
+      }
+    })
+
+    expect(result.status).toBe(1)
+    expect(mock.requests).toHaveLength(1)
+    const [request] = mock.requests
+    expect(request.method).toBe('POST')
+    expect(request.path).toBe(ISSUES_PATH)
+    expect(request.body).toMatchObject({
+      title: ISSUE_TITLE,
+      body: reportBody,
+      labels: ['security', 'audit'],
+      assignees: ['oke-py']
+    })
+  })
+
+  it('exits successfully when fail_on_vulnerabilities is false', async () => {
+    const mock = await withMockApi()
+
+    const result = await runAction({
+      apiUrl: mock.url,
+      eventName: 'push',
+      inputs: { fail_on_vulnerabilities: 'false' }
+    })
+
+    expect(result.status).toBe(0)
+    expect(mock.requests.map((r) => r.method)).toEqual(['POST'])
+  })
+
+  it('skips commenting on the existing issue when the report is unchanged', async () => {
+    const mock = await withMockApi({
+      issues: [{ number: 42, title: ISSUE_TITLE, body: null }],
+      comments: [{ id: 7, body: `${reportBody}\n\n${REPORT_MARKER}` }]
+    })
+
+    const result = await runAction({
+      apiUrl: mock.url,
+      eventName: 'push',
+      inputs: {
+        dedupe_issues: 'true',
+        dedupe_comments: 'true',
+        fail_on_vulnerabilities: 'false'
+      }
+    })
+
+    expect(result.status).toBe(0)
+    expect(mock.requests.map((r) => r.method)).toEqual(['GET', 'GET'])
+    expect(mock.requests[0].path).toContain(`${ISSUES_PATH}?`)
+    expect(mock.requests[1].path).toContain(
+      '/repos/oke-py/npm-audit-action/issues/42/comments'
+    )
+    expect(result.stdout).toContain('The report is unchanged')
+  })
+
+  it('comments on the existing issue when the report changed', async () => {
+    const mock = await withMockApi({
+      issues: [{ number: 42, title: ISSUE_TITLE, body: null }],
+      comments: [{ id: 7, body: `stale report\n\n${REPORT_MARKER}` }]
+    })
+
+    const result = await runAction({
+      apiUrl: mock.url,
+      eventName: 'push',
+      inputs: {
+        dedupe_issues: 'true',
+        dedupe_comments: 'true',
+        fail_on_vulnerabilities: 'false'
+      }
+    })
+
+    expect(result.status).toBe(0)
+    const posted = mock.requests.filter((r) => r.method === 'POST')
+    expect(posted).toHaveLength(1)
+    expect(posted[0].path).toBe(
+      '/repos/oke-py/npm-audit-action/issues/42/comments'
+    )
+    expect(posted[0].body.body).toBe(`${reportBody}\n\n${REPORT_MARKER}`)
+  })
+
+  it('marks previous pull request comments as resolved when the vulnerabilities are gone', async () => {
+    const mock = await withMockApi({
+      comments: [{ id: 7, body: `old report\n\n${REPORT_MARKER}` }]
+    })
+
+    const result = await runAction({
+      apiUrl: mock.url,
+      eventName: 'pull_request',
+      auditFixture: 'success.txt',
+      auditStatus: 0,
+      inputs: { resolve_pr_comments: 'true' }
+    })
+
+    expect(result.status).toBe(0)
+    expect(mock.requests.map((r) => r.method)).toEqual(['GET', 'PATCH'])
+    const patch = mock.requests[1]
+    expect(patch.path).toBe('/repos/oke-py/npm-audit-action/issues/comments/7')
+    expect(patch.body.body).toContain(RESOLVED_MARKER)
+    expect(patch.body.body).toContain('0123456')
+  })
+})

--- a/__tests__/e2e/helpers.ts
+++ b/__tests__/e2e/helpers.ts
@@ -1,0 +1,191 @@
+// Helpers for the end-to-end tests that run the bundled `dist/index.js` as a
+// child process against a local mock of the GitHub REST API.
+import { spawn } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as http from 'node:http'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+export const rootDir = path.resolve(here, '..', '..')
+export const bundlePath = path.join(rootDir, 'dist', 'index.js')
+export const eventDir = path.join(rootDir, '__tests__', 'testdata', 'event')
+export const auditDir = path.join(rootDir, '__tests__', 'testdata', 'audit')
+
+export type RecordedRequest = {
+  method: string
+  path: string
+  // biome-ignore lint/suspicious/noExplicitAny: request bodies are arbitrary JSON
+  body: any
+  authorization?: string
+}
+
+export type MockApiResponses = {
+  // returned by GET /repos/{owner}/{repo}/issues
+  issues?: Array<{ number: number; title: string; body?: string | null }>
+  // returned by GET /repos/{owner}/{repo}/issues/{n}/comments
+  comments?: Array<{ id: number; body?: string | null }>
+}
+
+export type MockApi = {
+  url: string
+  requests: RecordedRequest[]
+  close: () => Promise<void>
+}
+
+const ISSUES = /^\/repos\/([^/]+)\/([^/]+)\/issues$/
+const ISSUE_COMMENTS = /^\/repos\/([^/]+)\/([^/]+)\/issues\/(\d+)\/comments$/
+const COMMENT = /^\/repos\/([^/]+)\/([^/]+)\/issues\/comments\/(\d+)$/
+
+export async function startMockApi(
+  responses: MockApiResponses = {}
+): Promise<MockApi> {
+  const requests: RecordedRequest[] = []
+
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = []
+    req.on('data', (chunk: Buffer) => chunks.push(chunk))
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8')
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1')
+      requests.push({
+        method: req.method ?? '',
+        path: req.url ?? '',
+        body: raw ? JSON.parse(raw) : null,
+        authorization: req.headers.authorization
+      })
+
+      const send = (status: number, payload: unknown): void => {
+        res.writeHead(status, { 'content-type': 'application/json' })
+        res.end(JSON.stringify(payload))
+      }
+
+      const pathname = url.pathname
+      if (req.method === 'POST' && ISSUES.test(pathname)) {
+        send(201, { number: 1, html_url: 'https://example.test/issues/1' })
+        return
+      }
+      if (req.method === 'GET' && ISSUES.test(pathname)) {
+        send(200, responses.issues ?? [])
+        return
+      }
+      if (req.method === 'POST' && ISSUE_COMMENTS.test(pathname)) {
+        send(201, { id: 10, url: 'https://example.test/comments/10' })
+        return
+      }
+      if (req.method === 'GET' && ISSUE_COMMENTS.test(pathname)) {
+        send(200, responses.comments ?? [])
+        return
+      }
+      const commentMatch = COMMENT.exec(pathname)
+      if (req.method === 'PATCH' && commentMatch) {
+        send(200, { id: Number(commentMatch[3]) })
+        return
+      }
+      send(404, { message: `unexpected ${req.method} ${pathname}` })
+    })
+  })
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  if (address === null || typeof address === 'string') {
+    throw new Error('failed to start the mock API server')
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+  }
+}
+
+// `npm audit` must not hit the network and must produce a deterministic
+// report, so the action is run with a stub `npm` at the front of PATH.
+export function createNpmStub(fixture: string, status: number): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'npm-audit-action-e2e-'))
+  const script = `#!/bin/sh\ncat ${JSON.stringify(path.join(auditDir, fixture))}\nexit ${status}\n`
+  const file = path.join(dir, 'npm')
+  fs.writeFileSync(file, script, { mode: 0o755 })
+  return dir
+}
+
+export type RunOptions = {
+  inputs?: Record<string, string>
+  eventName?: string
+  eventFile?: string
+  apiUrl: string
+  auditFixture?: string
+  auditStatus?: number
+}
+
+// Mirrors the defaults declared in action.yml; the runner passes every input
+// with a default as an INPUT_* variable, and core.getBooleanInput throws when
+// one is missing.
+const defaultInputs: Record<string, string> = {
+  audit_level: 'low',
+  create_issues: 'true',
+  create_pr_comments: 'true',
+  fail_on_vulnerabilities: 'true',
+  dedupe_comments: 'false',
+  dedupe_issues: 'false',
+  issue_title: 'npm audit found vulnerabilities',
+  json_flag: 'false',
+  production_flag: 'false',
+  report_format: 'text',
+  resolve_pr_comments: 'false',
+  github_token: 'test-token'
+}
+
+export type RunResult = {
+  status: number | null
+  stdout: string
+  stderr: string
+}
+
+// The mock API runs in this process, so the child must be spawned
+// asynchronously: spawnSync would block the event loop and the server would
+// never answer the request.
+export async function runAction(options: RunOptions): Promise<RunResult> {
+  const inputs = { ...defaultInputs, ...options.inputs }
+  const env: Record<string, string> = {
+    PATH: `${createNpmStub(options.auditFixture ?? 'error.txt', options.auditStatus ?? 1)}${path.delimiter}${process.env.PATH ?? ''}`,
+    HOME: process.env.HOME ?? os.homedir(),
+    GITHUB_API_URL: options.apiUrl,
+    GITHUB_REPOSITORY: 'oke-py/npm-audit-action',
+    GITHUB_EVENT_NAME: options.eventName ?? 'push',
+    GITHUB_EVENT_PATH: path.join(
+      eventDir,
+      options.eventFile ?? 'pull_request.json'
+    )
+  }
+  for (const [key, value] of Object.entries(inputs)) {
+    env[`INPUT_${key.toUpperCase()}`] = value
+  }
+
+  return new Promise<RunResult>((resolve, reject) => {
+    const child = spawn(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      env
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk
+    })
+    child.on('error', reject)
+    child.on('close', (status) => {
+      resolve({ status, stdout, stderr })
+    })
+  })
+}

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "package": "npx rolldown --config rolldown.config.ts",
     "prepare": "husky",
     "test": "vitest --run",
+    "test:e2e": "vitest --run --config vitest.e2e.config.ts",
     "test:coverage": "vitest --run --coverage",
-    "all": "npm run format:write && npm run lint && npm run typecheck && npm run test:coverage && npm run package"
+    "all": "npm run format:write && npm run lint && npm run typecheck && npm run test:coverage && npm run package && npm run test:e2e"
   },
   "repository": {
     "type": "git",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['__tests__/**/*.test.ts'],
+    // the end-to-end tests need a built bundle; see vitest.e2e.config.ts
+    exclude: ['__tests__/e2e/**'],
     coverage: {
       include: ['src/**/*.ts'], // Only target the src directory
       exclude: ['lib/**', '__fixtures__/**', '__tests__/**'], // Exclude the lib directory

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+
+// End-to-end tests run the built `dist/index.js`, so they live in their own
+// project and are not part of `npm run test`. Run `npm run package` first.
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['__tests__/e2e/**/*.test.ts'],
+    testTimeout: 60000,
+    // each test spawns a child process and binds a port
+    fileParallelism: false
+  }
+})


### PR DESCRIPTION
Closes #395

Same content as #403, which was merged into #407's branch rather than into `main`, so #395 stayed open. This re-targets it at `main`.

Rebased onto `main` now that #407 has landed, so the diff is the end-to-end suite alone. The `GITHUB_API_URL` fix it depends on is already on `main`.

## What

`__tests__/e2e/` spawns `node dist/index.js` as a child process with `INPUT_*` variables, `GITHUB_EVENT_NAME`/`GITHUB_EVENT_PATH` on the existing fixtures, a stub `npm` on `PATH`, and `GITHUB_API_URL` pointing at a `node:http` mock of the five REST endpoints the action uses. Assertions are on the recorded requests (method, path, body, auth header) and the child's exit code.

CI runs it in the `build` job right after `npm run package`, so it always tests the current bundle.

## Scenarios covered

| Scenario | Asserted |
| --- | --- |
| PR event, `create_pr_comments: true` | `POST /issues/100/comments` with the report body, exit 1 |
| PR event, `create_pr_comments: false` | no API call, exit 0 |
| push event, `create_issues: true` | `POST /issues` with title, body, labels, assignees |
| `fail_on_vulnerabilities: false` | exit 0 |
| `dedupe_issues` + `dedupe_comments`, unchanged report | `listForRepo` + `listComments` only, no comment posted |
| `dedupe_issues` + `dedupe_comments`, changed report | comment posted on the existing issue |
| PR event, `resolve_pr_comments: true`, no vulnerabilities | `PATCH /issues/comments/7` with the resolved marker |

That exercises all five endpoints: `issues.create`, `issues.listForRepo`, `issues.createComment`, `issues.listComments`, `issues.updateComment`.

## Notes

- The suite needs no secrets, no network and creates nothing in this repository. `npm audit` is stubbed with a small shell script on `PATH` so the report is deterministic.
- It lives in its own vitest project (`npm run test:e2e`, `vitest.e2e.config.ts`) and is excluded from `npm run test`, because it requires a built `dist/`.
- It is skipped on Windows, where the `npm` stub would have to be a batch file; `test-on-windows` still runs the bundle there.
- The issue lists "PR event with `dedupe_comments: true`" — `dedupe_comments` only applies to the issue flow, so the unchanged-report scenario is asserted there, and the PR side is covered by `resolve_pr_comments` instead.

## Testing

`npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run test` (125 passed), `npm run package`, `npm run test:e2e` (8 passed) locally against the current `main` dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

